### PR TITLE
add scroll bar for labels panel

### DIFF
--- a/salt/interface.py
+++ b/salt/interface.py
@@ -1,5 +1,6 @@
 import cv2
 from PyQt5.QtWidgets import (
+    QScrollArea,
     QWidget,
     QVBoxLayout,
     QLabel,
@@ -208,7 +209,12 @@ class ApplicationInterface(QWidget):
                 "background-color: rgba({},{},{},0.6)".format(*colors[i][::-1])
             )
             panel_layout.addWidget(label_array[i])
-        return panel
+
+        scroll = QScrollArea()
+        scroll.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        scroll.setWidget(panel)
+        scroll.setFixedWidth(200)
+        return scroll
 
     def get_side_panel_annotations(self):
         anns, colors = self.editor.list_annotations()


### PR DESCRIPTION
This adds scrollbars to the label panel so all labels can be selected in the case of overflow:
![DeepinScreenshot_20230420083245](https://user-images.githubusercontent.com/4982789/233381723-d88faeb5-3f3d-453b-bc4b-21b422c23735.png)
