### PR TITLE
Replace skimage.measure.find_contours with cv2.findContours in parse_mask_to_coco function.

### DIFF
--- a/salt/dataset_explorer.py
+++ b/salt/dataset_explorer.py
@@ -70,7 +70,7 @@ def parse_mask_to_coco(image_id, anno_id, image_mask, category_id, poly=False):
         fortran_binary_mask = np.asfortranarray(image_mask)
         encoded_mask = mask.encode(fortran_binary_mask)
     if poly == True:
-        contours = measure.find_contours(image_mask, 0.5)
+        contours, _ = cv2.findContours(image_mask.astype(np.uint8), cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
     annotation = {
         "id": start_anno_id,
         "image_id": image_id,
@@ -87,11 +87,7 @@ def parse_mask_to_coco(image_id, anno_id, image_mask, category_id, poly=False):
         )
     if poly == True:
         for contour in contours:
-            contour = np.flip(contour, axis=1)
-            segmentation = contour.ravel().tolist()
-            sc = bunch_coords(segmentation)
-            sc = simplify_coords_vwp(sc, 2)
-            sc = unbunch_coords(sc)
+            sc = simplify_coords_vwp(contour[:,0,:], 2).ravel().tolist()
             annotation["segmentation"].append(sc)
     return annotation
 


### PR DESCRIPTION
Since `skimage.measure.find_contours` does not guarantee to include corner point when the mask cover the corner, I replace it with `cv2.findContours`.

Example

1. Add a point to mask the background
   ![example_1](https://user-images.githubusercontent.com/47732830/235279774-17efed32-e619-4f60-9c85-a959d80d7d7f.png)

2. Press Add button
   - `skimage.measure.find_contours` - In this case the polygon is considered self-intersecting because it does not contain the top left and top right points of the image.
     ![example_2](https://user-images.githubusercontent.com/47732830/235279816-d1a054aa-7149-46fd-b664-fdf8409890df.png)
   - `cv2.findContours`
     ![example_3](https://user-images.githubusercontent.com/47732830/235279843-166c0d3e-0681-4f8e-9f28-a45ae9a18442.png)

Thanks

